### PR TITLE
add C to auto-hide languages

### DIFF
--- a/auto-hide.el
+++ b/auto-hide.el
@@ -48,6 +48,8 @@
                      (body-field . "body")))
     (c++-ts-mode . ((function-node . "function_definition")
                     (body-field . "body")))
+    (c-ts-mode . ((function-node . "function_definition")
+		  (body-field . "body")))
     (js-ts-mode . ((function-node . "function_declaration")
                    (body-field . "body")))
     (python-ts-mode . ((function-node . "function_definition")


### PR DESCRIPTION
Never done one of these, but here's a contribution. Just added c-ts-mode, works just like c++-ts-mode.